### PR TITLE
Fixed latent pinning bug related to OID sets

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -106,6 +106,7 @@ jobs:
             PKGS="${PKGS} heimdal"
           fi
 
+          echo Installing packages: ${PKGS}
           pkg install -y ${PKGS}
 
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ toolbin/
 
 coverage.html
 go-gssapi-c.test
+*.code-workspace

--- a/contrib/pinning/go.mod
+++ b/contrib/pinning/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.25.1
+go 1.24
 
 require github.com/stretchr/testify v1.11.1
 

--- a/helpers_mac.go
+++ b/helpers_mac.go
@@ -45,6 +45,8 @@ func oid2Coid(oid g.Oid, pinner *runtime.Pinner) (C.gss_OID, *runtime.Pinner) {
 	if len(oid) > 0 {
 		pinner.Pin(&oid[0])
 		var cOid C.gss_OID_desc
+
+		// Go doesn't know about the elements field of the gss_OID_desc struct due to alignment issues
 		C._set_oid_fields(&cOid, C.OM_uint32(len(oid)), unsafe.Pointer(&oid[0]))
 		return &cOid, pinner
 	} else {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -2,48 +2,9 @@ package gssapi
 
 import (
 	"testing"
-	"unsafe"
 
 	g "github.com/golang-auth/go-gssapi/v3"
 )
-
-func TestGssOidSetFromOids(t *testing.T) {
-	assert := NewAssert(t)
-
-	oids := []g.Oid{}
-
-	// test with no OIDs
-	oidSet, pinner := gssOidSetFromOids(oids, nil)
-	assert.NotNil(pinner)
-	if pinner != nil {
-		pinner.Unpin()
-	}
-	assert.Nil(oidSet)
-
-	mechs := []g.GssMech{g.GSS_MECH_KRB5, g.GSS_MECH_IAKERB}
-
-	// Test with some OIDs
-	oids = append(oids, mechs[0].Oid(), mechs[1].Oid())
-	oidSet, pinner = gssOidSetFromOids(oids, nil)
-	assert.NotNil(oidSet)
-	assert.NotNil(pinner)
-
-	if oidSet != nil {
-		assert.Equal(2, int(oidSet.count))
-
-		elms := oidSet.elements
-		s := unsafe.Slice(elms, oidSet.count)
-		for i, cOid := range s {
-			oid := oidFromGssOid(&cOid)
-			oidString, err := oid2String(oid)
-			assert.NoErrorFatal(err)
-			assert.Equal(mechs[i].OidString(), oidString)
-		}
-	}
-	if pinner != nil {
-		pinner.Unpin()
-	}
-}
 
 func TestOid2String(t *testing.T) {
 	assert := NewAssert(t)

--- a/helpers_unix.go
+++ b/helpers_unix.go
@@ -17,6 +17,10 @@ import (
 import "C"
 
 func oidFromGssOid(cOid C.gss_OID) g.Oid {
+	if cOid == C.GSS_C_NO_OID {
+		return nil
+	}
+
 	return C.GoBytes(cOid.elements, C.int(cOid.length))
 }
 
@@ -30,10 +34,12 @@ func oid2Coid(oid g.Oid, pinner *runtime.Pinner) (C.gss_OID, *runtime.Pinner) {
 	}
 
 	if len(oid) > 0 {
+		p := unsafe.Pointer(&oid[0])
 		pinner.Pin(&oid[0])
+
 		return &C.gss_OID_desc{
 			length:   C.OM_uint32(len(oid)),
-			elements: unsafe.Pointer(&oid[0]),
+			elements: p,
 		}, pinner
 	} else {
 		return C.GSS_C_NO_OID, pinner

--- a/oidset.go
+++ b/oidset.go
@@ -1,0 +1,58 @@
+package gssapi
+
+import (
+	"runtime"
+
+	g "github.com/golang-auth/go-gssapi/v3"
+)
+
+/*
+#include "gss.h"
+*/
+import "C"
+
+type oidSet struct {
+	pinner *runtime.Pinner
+	oidSet C.gss_OID_set
+}
+
+func newOidSet(oids []g.Oid) (*oidSet, error) {
+	ret := &oidSet{
+		pinner: &runtime.Pinner{},
+		oidSet: nil,
+	}
+
+	if len(oids) == 0 {
+		return ret, nil
+	}
+
+	var cMinor C.OM_uint32
+	cMajor := C.gss_create_empty_oid_set(&cMinor, &ret.oidSet)
+	if cMajor != C.GSS_S_COMPLETE {
+		return nil, makeStatus(cMajor, cMinor)
+	}
+
+	for _, oid := range oids {
+		cOid, _ := oid2Coid(oid, ret.pinner)
+		cMajor := C.gss_add_oid_set_member(&cMinor, cOid, &ret.oidSet)
+		if cMajor != C.GSS_S_COMPLETE {
+			return nil, makeStatus(cMajor, cMinor)
+		}
+	}
+
+	return ret, nil
+}
+
+func (o *oidSet) Release() error {
+	if o == nil || o.oidSet == nil {
+		return nil
+	}
+
+	var minor C.OM_uint32
+	cMajor := C.gss_release_oid_set(&minor, &o.oidSet)
+	if cMajor != C.GSS_S_COMPLETE {
+		return makeStatus(cMajor, minor)
+	}
+	o.pinner.Unpin()
+	return nil
+}

--- a/oidset_test.go
+++ b/oidset_test.go
@@ -1,0 +1,41 @@
+package gssapi
+
+import (
+	"testing"
+	"unsafe"
+
+	g "github.com/golang-auth/go-gssapi/v3"
+)
+
+func TestOidSet(t *testing.T) {
+	assert := NewAssert(t)
+
+	oids := []g.Oid{}
+
+	// test with no OIDs
+	oidSet, err := newOidSet(oids)
+	assert.NoError(err)
+	assert.NotNil(oidSet)
+
+	mechs := []g.GssMech{g.GSS_MECH_KRB5, g.GSS_MECH_IAKERB}
+
+	// Test with some OIDs
+	oids = append(oids, mechs[0].Oid(), mechs[1].Oid())
+	oidSet, err = newOidSet(oids)
+	assert.NoErrorFatal(err)
+	assert.NotNil(oidSet)
+
+	if oidSet != nil {
+		assert.Equal(2, int(oidSet.oidSet.count))
+
+		elms := oidSet.oidSet.elements
+		s := unsafe.Slice(elms, oidSet.oidSet.count)
+		assert.Equal(2, len(s))
+		for i, cOid := range s {
+			oid := oidFromGssOid(&cOid)
+			oidString, err := oid2String(oid)
+			assert.NoErrorFatal(err)
+			assert.Equal(mechs[i].OidString(), oidString)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4 

The Go code that built up OID sets was faults because the resultant array of OID pointers was not from a single allocation and so turning that back into a Go slice would fail.

We moved to using the C GSSAPI Oid-set builder instead.

Additionally use the OS/arch in the toolbin path to avoid clashes when testing on multiple platforms with a single checkout.