### PR TITLE
Fixes from a Claude code review

### DIFF
--- a/cred_ext.go
+++ b/cred_ext.go
@@ -159,9 +159,8 @@ func (s credStore) kv() *kvset {
 
 	elms := make([]C.struct_gss_key_value_element_struct, 0, len(s))
 	for opt, value := range s {
-		elm := C.gss_key_value_element_desc{
-			value: C.CString(value),
-		}
+		elm := C.gss_key_value_element_desc{}
+
 		switch opt {
 		default:
 			continue
@@ -179,6 +178,7 @@ func (s credStore) kv() *kvset {
 			elm.key = C.CString("verify")
 		}
 
+		elm.value = C.CString(value)
 		elms = append(elms, elm)
 	}
 
@@ -209,9 +209,8 @@ func (k *kvset) Get(idx int) *C.struct_gss_key_value_element_struct {
 	if idx >= int(k.kvset.count) {
 		return nil
 	}
-	usp := unsafe.Pointer(k.kvset.elements)
-	usp = unsafe.Pointer(uintptr(usp) + uintptr(idx)*unsafe.Sizeof(C.struct_gss_key_value_element_struct{}))
-	return (*C.struct_gss_key_value_element_struct)(usp)
+	return (*C.struct_gss_key_value_element_struct)(
+		unsafe.Add(unsafe.Pointer(k.kvset.elements), idx*int(unsafe.Sizeof(C.struct_gss_key_value_element_struct{}))))
 }
 
 func (k *kvset) kv(idx int) (string, string) {
@@ -289,7 +288,7 @@ func (c *Credential) StoreInto(mech g.GssMech, usage g.CredUsage, overwrite bool
 	var cMinor C.OM_uint32
 	var cOverwrite, cDefaultCred C.OM_uint32
 	var cUsageStored C.gss_cred_usage_t
-	var cElementsStored C.gss_OID_set
+	var cElementsStored C.gss_OID_set // allocated by GSSAPI; released by *1
 	if overwrite {
 		cOverwrite = 1
 	}
@@ -304,6 +303,9 @@ func (c *Credential) StoreInto(mech g.GssMech, usage g.CredUsage, overwrite bool
 	if cMajor != C.GSS_S_COMPLETE {
 		return nil, 0, makeStatus(cMajor, cMinor)
 	}
+
+	// *1  release GSSAPI allocated array
+	defer C.gss_release_oid_set(&cMinor, &cElementsStored)
 
 	mechs := make([]g.GssMech, 0, cElementsStored.count)
 	mechOids := oidsFromGssOidSet(cElementsStored)
@@ -328,6 +330,7 @@ func (c *Credential) StoreInto(mech g.GssMech, usage g.CredUsage, overwrite bool
 func (c *Credential) AddFrom(name g.GssName, mech g.GssMech, usage g.CredUsage, initiatorLifetime *g.GssLifetime, acceptorLifetime *g.GssLifetime, mutate bool, opts ...g.CredStoreOption) (g.Credential, error) { // coverage-ignore
 	var cMechOid C.gss_OID = C.GSS_C_NO_OID
 	pinner := &runtime.Pinner{}
+	defer pinner.Unpin()
 	if mech != nil {
 		cMechOid, _ = oid2Coid(mech.Oid(), pinner)
 	}

--- a/helpers_unix.go
+++ b/helpers_unix.go
@@ -34,8 +34,8 @@ func oid2Coid(oid g.Oid, pinner *runtime.Pinner) (C.gss_OID, *runtime.Pinner) {
 	}
 
 	if len(oid) > 0 {
-		p := unsafe.Pointer(&oid[0])
 		pinner.Pin(&oid[0])
+		p := unsafe.Pointer(&oid[0])
 
 		return &C.gss_OID_desc{
 			length:   C.OM_uint32(len(oid)),

--- a/oidset.go
+++ b/oidset.go
@@ -1,6 +1,7 @@
 package gssapi
 
 import (
+	"fmt"
 	"runtime"
 
 	g "github.com/golang-auth/go-gssapi/v3"
@@ -36,7 +37,11 @@ func newOidSet(oids []g.Oid) (*oidSet, error) {
 		cOid, _ := oid2Coid(oid, ret.pinner)
 		cMajor := C.gss_add_oid_set_member(&cMinor, cOid, &ret.oidSet)
 		if cMajor != C.GSS_S_COMPLETE {
-			return nil, makeStatus(cMajor, cMinor)
+			err := makeStatus(cMajor, cMinor)
+			if errRel := ret.Release(); errRel != nil {
+				err = fmt.Errorf("oidset release failed (%w) while handling %w", errRel, err)
+			}
+			return nil, err
 		}
 	}
 

--- a/symbols.go
+++ b/symbols.go
@@ -10,6 +10,7 @@ import (
 /*
 #include <dlfcn.h>
 #include <stdint.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -33,14 +34,16 @@ func readSymbols() {
 
 	cDlHandle := C.dlopen(nil, C.RTLD_NOW)
 	if cDlHandle == nil {
-		panic("faied to open library")
+		panic("failed to open library")
 	}
 
 	defer C.dlclose(cDlHandle)
 
 	for _, sym := range syms {
-		ptr := C.dlsym(cDlHandle, C.CString(sym))
+		symStr := C.CString(sym)
+		ptr := C.dlsym(cDlHandle, symStr)
 		optionalSymbols[sym] = ptr
+		C.free(unsafe.Pointer(symStr))
 	}
 }
 


### PR DESCRIPTION
Fixes the following issues:

  Critical — Memory leaks / resource management

  1. oidset.go:38-40 — OID set leaked on partial failure

  If gss_create_empty_oid_set succeeds but a subsequent gss_add_oid_set_member call fails, ret.oidSet is allocated but
  never released:

  for _, oid := range oids {
      cOid, _ := oid2Coid(oid, ret.pinner)
      cMajor := C.gss_add_oid_set_member(&cMinor, cOid, &ret.oidSet)
      if cMajor != C.GSS_S_COMPLETE {
          return nil, makeStatus(cMajor, cMinor)  // ret.oidSet leaked
      }
  }

  Fix: call C.gss_release_oid_set (and ret.pinner.Unpin()) before the error return.

  ---
  2. cred_ext.go:330 — AddFrom pinner never unpinned

  pinner := &runtime.Pinner{}
  if mech != nil {
      cMechOid, _ = oid2Coid(mech.Oid(), pinner)
  }
  // ... no defer pinner.Unpin()

  When mech != nil, the OID backing memory is pinned but never unpinned. Add defer pinner.Unpin() immediately after the
  pinner is created (mirrors the pattern in StoreInto just below it).

  ---
  3. cred_ext.go:292, 309 — StoreInto leaks GSSAPI-allocated OID set

  gss_store_cred_into allocates cElementsStored but there is no defer C.gss_release_oid_set(&cMinor, &cElementsStored)
  after the success check. This leaks on every successful call.

  ---
  Medium — CGo rule violations

  4. symbols.go:42 — C.CString leak in readSymbols

  ptr := C.dlsym(cDlHandle, C.CString(sym))

  The C string allocated by C.CString is never freed. Since readSymbols runs only once via sync.Once the total leak is
  bounded, but it violates the CGo contract. Each C.CString result should be held in a variable and passed to C.free.

  ---
  5. helpers_unix.go:37-38 — unsafe.Pointer captured before Pin

  p := unsafe.Pointer(&oid[0])  // address captured here
  pinner.Pin(&oid[0])            // pinned here — too late

  The old code was correct: pinner.Pin was called first, then the address was taken in the struct literal. If the GC runs a
   compaction between these two lines, p would be stale. Swap the two lines: pin first, then assign p.

  ---
  6. cred_ext.go:284-286 — multi-step uintptr arithmetic violates CGo rules

  usp := unsafe.Pointer(k.kvset.elements)
  usp = unsafe.Pointer(uintptr(usp) + uintptr(idx)*unsafe.Sizeof(...))

  CGo requires that the conversion from unsafe.Pointer → uintptr → unsafe.Pointer happen in a single expression. Storing
  the intermediate uintptr in a variable (even implicitly via two statements) is prohibited by the unsafe.Pointer rules.
  The elements are pinned here so it works in practice, but replace with unsafe.Add:

  return (*C.struct_gss_key_value_element_struct)(
      unsafe.Add(unsafe.Pointer(k.kvset.elements), idx*int(unsafe.Sizeof(C.struct_gss_key_value_element_struct{}))))

  ---
  7. cred_ext.go:234 — C.CString(value) leaked for unknown option types

  In credStore.kv(), elm.value = C.CString(value) is allocated before the switch. If the default: continue branch is taken
  (unknown option key), elm is discarded and elm.value is never freed by Release(). Allocate elm.value only inside the
  matching case branches, after confirming the key is known.
