### PR TITLE
Another round of fixes from a Claude review

### DIFF
--- a/cred.go
+++ b/cred.go
@@ -76,7 +76,7 @@ func (c *Credential) Release() error {
 
 func (c *Credential) Inquire() (*g.CredInfo, error) {
 	var minor C.OM_uint32
-	var cGssName C.gss_name_t // cGssName allocated by GSSAPI; releaseed by *1
+	var cGssName C.gss_name_t // cGssName allocated by GSSAPI; released by *1
 	var cTimeRec C.OM_uint32
 	var cCredUsage C.gss_cred_usage_t
 	var cMechs C.gss_OID_set // cActualMechs.elements allocated by GSSAPI; released by *2
@@ -203,6 +203,7 @@ func (c *Credential) Add(name g.GssName, mech g.GssMech, usage g.CredUsage, init
 
 	var cMechOid C.gss_OID = C.GSS_C_NO_OID
 	pinner := &runtime.Pinner{}
+	defer pinner.Unpin()
 	if mech != nil {
 		cMechOid, _ = oid2Coid(mech.Oid(), pinner)
 	}
@@ -232,6 +233,10 @@ func (c *Credential) Add(name g.GssName, mech g.GssMech, usage g.CredUsage, init
 	if mutate {
 		return c, nil
 	} else {
-		return &Credential{id: cCredOut}, nil
+		return &Credential{
+			id:           cCredOut,
+			usage:        usage,
+			isFromNoName: cGssName == C.GSS_C_NO_NAME,
+		}, nil
 	}
 }

--- a/cred_ext.go
+++ b/cred_ext.go
@@ -67,8 +67,8 @@ OM_uint32 _gss_store_cred_into(OM_uint32 *minor_status,
                                   gss_cred_usage_t *cred_usage_stored)
 								  {
 	if( __gss_store_cred_into == NULL ) {
-	*minor_status = 0;
-	return GSS_S_UNAVAILABLE;
+		*minor_status = 0;
+		return GSS_S_UNAVAILABLE;
 	}
 	return __gss_store_cred_into(minor_status, input_cred_handle, cred_usage, desired_mech, overwrite_cred, default_cred, cred_store, elements_stored, cred_usage_stored);
 }
@@ -144,13 +144,20 @@ func (s credStore) GetOption(option int) (string, bool) {
 }
 
 type kvset struct {
-	kvset  C.gss_const_key_value_set_t
+	set    *C.struct_gss_key_value_set_struct
 	pinner *runtime.Pinner
+}
+
+func (k *kvset) constSet() C.gss_const_key_value_set_t {
+	if k.set == nil {
+		return nil
+	}
+	return (C.gss_const_key_value_set_t)(unsafe.Pointer(k.set))
 }
 
 func (s credStore) kv() *kvset {
 	kvs := kvset{
-		kvset: &C.gss_key_value_set_desc{
+		set: &C.struct_gss_key_value_set_struct{
 			count:    0,
 			elements: nil,
 		},
@@ -183,17 +190,17 @@ func (s credStore) kv() *kvset {
 	}
 
 	if len(elms) > 0 {
-		kvs.kvset.elements = unsafe.SliceData(elms)
-		kvs.kvset.count = C.OM_uint32(len(elms))
+		kvs.set.elements = unsafe.SliceData(elms)
+		kvs.set.count = C.OM_uint32(len(elms))
 
-		kvs.pinner.Pin(kvs.kvset.elements)
+		kvs.pinner.Pin(kvs.set.elements)
 	}
 
 	return &kvs
 }
 
 func (k *kvset) Release() {
-	for i := 0; i < int(k.kvset.count); i++ {
+	for i := 0; i < int(k.set.count); i++ {
 		elm := k.Get(i)
 		if elm == nil {
 			continue
@@ -206,11 +213,11 @@ func (k *kvset) Release() {
 }
 
 func (k *kvset) Get(idx int) *C.struct_gss_key_value_element_struct {
-	if idx >= int(k.kvset.count) {
+	if idx >= int(k.set.count) {
 		return nil
 	}
 	return (*C.struct_gss_key_value_element_struct)(
-		unsafe.Add(unsafe.Pointer(k.kvset.elements), idx*int(unsafe.Sizeof(C.struct_gss_key_value_element_struct{}))))
+		unsafe.Add(unsafe.Pointer(k.set.elements), idx*int(unsafe.Sizeof(C.struct_gss_key_value_element_struct{}))))
 }
 
 func (k *kvset) kv(idx int) (string, string) {
@@ -254,7 +261,7 @@ func (provider) AcquireCredentialFrom(name g.GssName, mechs []g.GssMech, usage g
 
 	var cMinor C.OM_uint32
 	var cCredID C.gss_cred_id_t = C.GSS_C_NO_CREDENTIAL
-	cMajor := C._gss_acquire_cred_from(&cMinor, cGssName, gssLifetimeToSeconds(lifetime), cOidSet.oidSet, C.int(usage), kv.kvset, &cCredID, nil, nil)
+	cMajor := C._gss_acquire_cred_from(&cMinor, cGssName, gssLifetimeToSeconds(lifetime), cOidSet.oidSet, C.int(usage), kv.constSet(), &cCredID, nil, nil)
 
 	if cMajor != C.GSS_S_COMPLETE {
 		return nil, makeStatus(cMajor, cMinor)
@@ -298,7 +305,7 @@ func (c *Credential) StoreInto(mech g.GssMech, usage g.CredUsage, overwrite bool
 	cMechOid, pinner := oid2Coid(mechOid, nil)
 	defer pinner.Unpin()
 
-	cMajor := C._gss_store_cred_into(&cMinor, c.id, C.int(usage), cMechOid, cOverwrite, cDefaultCred, kv.kvset, &cElementsStored, &cUsageStored)
+	cMajor := C._gss_store_cred_into(&cMinor, c.id, C.int(usage), cMechOid, cOverwrite, cDefaultCred, kv.constSet(), &cElementsStored, &cUsageStored)
 
 	if cMajor != C.GSS_S_COMPLETE {
 		return nil, 0, makeStatus(cMajor, cMinor)
@@ -362,7 +369,7 @@ func (c *Credential) AddFrom(name g.GssName, mech g.GssMech, usage g.CredUsage, 
 		cpCredOut = &cCredOut
 	}
 
-	major := C._gss_add_cred_from(&minor, c.id, cGssName, cMechOid, C.int(usage), gssLifetimeToSeconds(initiatorLifetime), gssLifetimeToSeconds(acceptorLifetime), kv.kvset, cpCredOut, nil, nil, nil)
+	major := C._gss_add_cred_from(&minor, c.id, cGssName, cMechOid, C.int(usage), gssLifetimeToSeconds(initiatorLifetime), gssLifetimeToSeconds(acceptorLifetime), kv.constSet(), cpCredOut, nil, nil, nil)
 	if major != C.GSS_S_COMPLETE {
 		return nil, makeMechStatus(major, minor, mech)
 	}
@@ -370,6 +377,10 @@ func (c *Credential) AddFrom(name g.GssName, mech g.GssMech, usage g.CredUsage, 
 	if mutate {
 		return c, nil
 	} else {
-		return &Credential{id: cCredOut}, nil
+		return &Credential{
+			id:           cCredOut,
+			usage:        usage,
+			isFromNoName: cGssName == C.GSS_C_NO_NAME,
+		}, nil
 	}
 }

--- a/cred_ext_test.go
+++ b/cred_ext_test.go
@@ -105,8 +105,8 @@ func TestCredStoreKvEmpty(t *testing.T) {
 	store := newCredStore()
 
 	kv := store.kv()
-	assert.NotNil(kv.kvset)
-	assert.Equal(0, int(kv.kvset.count))
+	assert.NotNil(kv.set)
+	assert.Equal(0, int(kv.set.count))
 
 	kv.Release()
 }
@@ -121,9 +121,9 @@ func TestCredStoreKvSingleOption(t *testing.T) {
 	kv := store.kv()
 	defer kv.Release()
 
-	assert.NotNil(kv.kvset)
-	assert.Equal(1, int(kv.kvset.count))
-	assert.NotNil(kv.kvset.elements)
+	assert.NotNil(kv.set)
+	assert.Equal(1, int(kv.set.count))
+	assert.NotNil(kv.set.elements)
 
 	key, value := kv.kv(0)
 	assert.Equal("ccache", key)
@@ -155,9 +155,9 @@ func TestCredStoreKvOptionKeyMappings(t *testing.T) {
 			kvset := store.kv()
 			defer kvset.Release()
 
-			assert.NotNil(kvset.kvset)
-			assert.Equal(1, int(kvset.kvset.count))
-			assert.NotNil(kvset.kvset.elements)
+			assert.NotNil(kvset.set)
+			assert.Equal(1, int(kvset.set.count))
+			assert.NotNil(kvset.set.elements)
 
 			kv := kvset.Get(0)
 			assert.NotNil(kv.key)
@@ -192,9 +192,9 @@ func TestCredStoreKvAllOptions(t *testing.T) {
 	kvset := store.kv()
 	defer kvset.Release()
 
-	assert.NotNil(kvset.kvset)
-	assert.Equal(len(testValues), int(kvset.kvset.count))
-	assert.NotNil(kvset.kvset.elements)
+	assert.NotNil(kvset.set)
+	assert.Equal(len(testValues), int(kvset.set.count))
+	assert.NotNil(kvset.set.elements)
 }
 
 func TestCredStoreKv(t *testing.T) {
@@ -208,8 +208,8 @@ func TestCredStoreKv(t *testing.T) {
 	kvset := store.kv()
 	defer kvset.Release()
 
-	assert.NotNil(kvset.kvset)
-	assert.Equal(1, int(kvset.kvset.count))
+	assert.NotNil(kvset.set)
+	assert.Equal(1, int(kvset.set.count))
 }
 
 func TestCredStoreKvUnknownOption(t *testing.T) {
@@ -223,9 +223,9 @@ func TestCredStoreKvUnknownOption(t *testing.T) {
 	kvset := store.kv()
 	defer kvset.Release()
 
-	assert.NotNil(kvset.kvset)
-	assert.Equal(0, int(kvset.kvset.count))
-	assert.Nil(kvset.kvset.elements)
+	assert.NotNil(kvset.set)
+	assert.Equal(0, int(kvset.set.count))
+	assert.Nil(kvset.set.elements)
 
 	kv := kvset.Get(0)
 	assert.Nil(kv)

--- a/helpers.go
+++ b/helpers.go
@@ -20,7 +20,7 @@ import (
 
 // Convert a Go OID to a string
 func oid2String(oid g.Oid) (string, error) {
-	objID := make(asn1.ObjectIdentifier, 100)
+	var objID asn1.ObjectIdentifier
 
 	oid = append([]byte{0x06, byte(len(oid))}, oid...)
 	_, err := asn1.Unmarshal(oid, &objID)
@@ -140,6 +140,30 @@ func gssLifetimeToSeconds(lifetime *g.GssLifetime) C.OM_uint32 {
 	default:
 		return C.OM_uint32(lifetime.ExpiresAt.Unix())
 	}
+}
+
+// gssRelease runs a GSSAPI release function on obj and converts its major/minor
+// status codes to a Go error via makeStatus.  Pass a typed shim such as
+// gssReleaseCred (cgo does not allow passing C.gss_release_cred as a Go func value).
+func gssRelease[T any](fn func(minor *C.OM_uint32, obj *T) C.OM_uint32, obj *T) error {
+	var minor C.OM_uint32
+	return makeStatus(fn(&minor, obj), minor)
+}
+
+func gssReleaseCred(minor *C.OM_uint32, cred *C.gss_cred_id_t) C.OM_uint32 {
+	return C.gss_release_cred(minor, cred)
+}
+
+func gssReleaseName(minor *C.OM_uint32, name *C.gss_name_t) C.OM_uint32 {
+	return C.gss_release_name(minor, name)
+}
+
+func gssReleaseBuffer(minor *C.OM_uint32, buf *C.gss_buffer_desc) C.OM_uint32 {
+	return C.gss_release_buffer(minor, buf)
+}
+
+func gssReleaseOidSet(minor *C.OM_uint32, set *C.gss_OID_set) C.OM_uint32 {
+	return C.gss_release_oid_set(minor, set)
 }
 
 func extractBufferSet(bs C.gss_buffer_set_t) [][]byte {

--- a/helpers_mac.go
+++ b/helpers_mac.go
@@ -5,6 +5,7 @@
 package gssapi
 
 import (
+	"math"
 	"runtime"
 	"unsafe"
 
@@ -42,7 +43,7 @@ func oid2Coid(oid g.Oid, pinner *runtime.Pinner) (C.gss_OID, *runtime.Pinner) {
 		pinner = &runtime.Pinner{}
 	}
 
-	if len(oid) > 0 {
+	if len(oid) > 0 && len(oid) <= math.MaxUint32 {
 		pinner.Pin(&oid[0])
 		var cOid C.gss_OID_desc
 

--- a/names.go
+++ b/names.go
@@ -126,7 +126,7 @@ func (n *GssName) Display() (string, g.GssNameType, error) {
 	oid := oidFromGssOid(cOutType)
 	nameType, err := g.NameTypeFromOid(oid)
 	if err != nil {
-		return "", g.GSS_NO_OID, makeStatus(major, minor)
+		return "", g.GSS_NO_OID, err
 	}
 
 	return string(name), nameType, nil

--- a/oidset.go
+++ b/oidset.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gssapi
 
 import (

--- a/provider.go
+++ b/provider.go
@@ -41,8 +41,8 @@ func (p provider) Name() string {
 	return LIBID
 }
 
-// ErrTooLarge indicates that the caller tried to operate on a m.  The C bindings
-// support a maximum 32-bit message.
+// ErrTooLarge indicates that the caller tried to operate on a message that is too large.
+// The C bindings support a maximum 32-bit message size.
 var ErrTooLarge = errors.New("the GSSAPI-C bindings only support up to 32 bit messages")
 
 func isHeimdal() bool {

--- a/seccontext.go
+++ b/seccontext.go
@@ -8,6 +8,7 @@ package gssapi
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"runtime"
@@ -131,7 +132,7 @@ func (c *SecContext) initSecContext() ([]byte, g.SecContextInfoPartial, error) {
 	defer C.gss_release_buffer(&cMinor, &cOutToken)
 
 	var outToken []byte = nil
-	if cOutToken != C.gss_empty_buffer {
+	if cOutToken.length > 0 {
 		outToken = C.GoBytes(cOutToken.value, C.int(cOutToken.length))
 	}
 	c.continueNeeded = (cMajor & C.GSS_S_CONTINUE_NEEDED) > 0
@@ -170,7 +171,7 @@ func splitFlags(flags C.OM_uint32) (g.ContextFlag, bool, bool) {
 
 func (c *SecContext) acceptSecContext(inputToken []byte) ([]byte, g.SecContextInfoPartial, error) {
 	// get the C cred ID and name
-	var cGssAcceptorCred, cGssDelegCred C.gss_cred_id_t = C.GSS_C_NO_CREDENTIAL, C.GSS_C_NO_CREDENTIAL
+	var cGssAcceptorCred C.gss_cred_id_t = C.GSS_C_NO_CREDENTIAL
 	if c.acceptOptions.Credential != nil {
 		credImpl, ok := c.acceptOptions.Credential.(*Credential) // must be *our* impl
 		if !ok {
@@ -189,24 +190,32 @@ func (c *SecContext) acceptSecContext(inputToken []byte) ([]byte, g.SecContextIn
 	}
 
 	var cMinor, cRetFlags, cTimeRec C.OM_uint32
-	var cInitiatorName C.gss_name_t = C.GSS_C_NO_NAME
+	var cInitiatorName C.gss_name_t = C.GSS_C_NO_NAME // allocated by GSSAPI; released by *2 on error
 	var cGssCtxID C.gss_ctx_id_t = C.GSS_C_NO_CONTEXT
 	var cOutToken C.gss_buffer_desc = C.gss_empty_buffer // cOutToken.value allocated by GSSAPI; released by *1
 	var cActualMech C.gss_OID = C.GSS_C_NO_OID
+	var cGssDelegCred C.gss_cred_id_t = C.GSS_C_NO_CREDENTIAL // allocated by GSSAPI; released by *3 on error
 	cInputToken, _ := bytesToCBuffer(inputToken, pinner)
 
 	cMajor := C.gss_accept_sec_context(&cMinor, &cGssCtxID, cGssAcceptorCred, &cInputToken, cChBindings, &cInitiatorName, &cActualMech, &cOutToken, &cRetFlags, &cTimeRec, &cGssDelegCred)
-	if cMajor != C.GSS_S_COMPLETE && (cMajor&C.GSS_S_CONTINUE_NEEDED) == 0 {
-		return nil, g.SecContextInfoPartial{}, makeStatus(cMajor, cMinor)
-	}
 
 	// *1  release GSSAPI allocated buffer
 	defer C.gss_release_buffer(&cMinor, &cOutToken)
 
+	// note that there might still be an output token if there is an error
 	var outToken []byte = nil
-	if cOutToken != C.gss_empty_buffer {
+	if cOutToken.length > 0 {
 		outToken = C.GoBytes(cOutToken.value, C.int(cOutToken.length))
 	}
+
+	if cMajor != C.GSS_S_COMPLETE && (cMajor&C.GSS_S_CONTINUE_NEEDED) == 0 {
+		var errs []error
+		errs = append(errs, gssRelease(gssReleaseCred, &cGssDelegCred))  // *3   release delegated credential
+		errs = append(errs, gssRelease(gssReleaseName, &cInitiatorName)) // *2   release initiator name
+		errs = append(errs, makeStatus(cMajor, cMinor))
+		return outToken, g.SecContextInfoPartial{}, errors.Join(errs...)
+	}
+
 	c.continueNeeded = (cMajor & C.GSS_S_CONTINUE_NEEDED) > 0
 	c.id = cGssCtxID
 	c.initiatorName = nameFromGssInternal(cInitiatorName)
@@ -231,7 +240,7 @@ func (c *SecContext) acceptSecContext(inputToken []byte) ([]byte, g.SecContextIn
 	}
 
 	if cGssDelegCred != C.GSS_C_NO_CREDENTIAL {
-		c.delegCred = &Credential{cGssDelegCred, g.CredUsageInitiateOnly, false}
+		c.delegCred = &Credential{id: cGssDelegCred, usage: g.CredUsageInitiateOnly, isFromNoName: false}
 		info.DelegatedCredential = c.delegCred
 	}
 
@@ -271,8 +280,8 @@ func (c *SecContext) Continue(inputToken []byte) ([]byte, g.SecContextInfoPartia
 	var cMajor, cMinor, cRetFlags, cTimeRec C.OM_uint32
 	var cOutToken C.gss_buffer_desc = C.gss_empty_buffer // cOutToken.value allocated by GSSAPI; released by *1
 	var cActualMech C.gss_OID = C.GSS_C_NO_OID
-	var cInitiatorName C.gss_name_t = C.GSS_C_NO_NAME
-	var cGssDelegCred C.gss_cred_id_t = C.GSS_C_NO_CREDENTIAL
+	var cInitiatorName C.gss_name_t = C.GSS_C_NO_NAME         // allocated by GSSAPI; released by *2 on error
+	var cGssDelegCred C.gss_cred_id_t = C.GSS_C_NO_CREDENTIAL // allocated by GSSAPI; released by *3 on error
 	cInputToken, pinner := bytesToCBuffer(inputToken, nil)
 	defer pinner.Unpin()
 
@@ -298,22 +307,27 @@ func (c *SecContext) Continue(inputToken []byte) ([]byte, g.SecContextInfoPartia
 		cMajor = C.gss_accept_sec_context(&cMinor, &c.id, C.GSS_C_NO_CREDENTIAL, &cInputToken, nil, cpInitiatorName, &cActualMech, &cOutToken, &cRetFlags, &cTimeRec, cpGssDelegCred)
 	}
 
-	if cMajor != C.GSS_S_COMPLETE && cMajor != C.GSS_S_CONTINUE_NEEDED {
-		return nil, g.SecContextInfoPartial{}, makeStatus(cMajor, cMinor)
-	}
-
 	// *1  release GSSAPI allocated buffer
 	defer C.gss_release_buffer(&cMinor, &cOutToken)
+
+	var outToken []byte = nil
+	if cOutToken.length > 0 {
+		outToken = C.GoBytes(cOutToken.value, C.int(cOutToken.length))
+	}
+
+	if cMajor != C.GSS_S_COMPLETE && cMajor != C.GSS_S_CONTINUE_NEEDED {
+		var errs []error
+		errs = append(errs, gssRelease(gssReleaseCred, &cGssDelegCred))  // *3   release delegated credential
+		errs = append(errs, gssRelease(gssReleaseName, &cInitiatorName)) // *2   release initiator name
+		errs = append(errs, makeStatus(cMajor, cMinor))
+		return outToken, g.SecContextInfoPartial{}, errors.Join(errs...)
+	}
 
 	// only if we're an acceptor and didn't already have an initiator name
 	if cInitiatorName != C.GSS_C_NO_NAME {
 		c.initiatorName = nameFromGssInternal(cInitiatorName)
 	}
 
-	var outToken []byte = nil
-	if cOutToken != C.gss_empty_buffer {
-		outToken = C.GoBytes(cOutToken.value, C.int(cOutToken.length))
-	}
 	c.continueNeeded = cMajor&C.GSS_S_CONTINUE_NEEDED > 0
 
 	ctxFlags, protFlag, transFlag := splitFlags(cRetFlags)
@@ -336,7 +350,7 @@ func (c *SecContext) Continue(inputToken []byte) ([]byte, g.SecContextInfoPartia
 	}
 
 	if cGssDelegCred != C.GSS_C_NO_CREDENTIAL {
-		c.delegCred = &Credential{cGssDelegCred, g.CredUsageInitiateOnly, false}
+		c.delegCred = &Credential{id: cGssDelegCred, usage: g.CredUsageInitiateOnly, isFromNoName: false}
 		info.DelegatedCredential = c.delegCred
 	}
 
@@ -351,29 +365,24 @@ func (c *SecContext) Delete() ([]byte, error) {
 	if c == nil {
 		return nil, nil
 	}
+	errs := []error{}
 	if c.initiatorName != nil {
-		if err := c.initiatorName.Release(); err != nil {
-			return nil, err
-		}
+		errs = append(errs, c.initiatorName.Release())
 		c.initiatorName = nil
 	}
 
 	if c.acceptorName != nil {
-		if err := c.acceptorName.Release(); err != nil {
-			return nil, err
-		}
+		errs = append(errs, c.acceptorName.Release())
 		c.acceptorName = nil
 	}
 
 	if c.delegCred != nil {
-		if err := c.delegCred.Release(); err != nil {
-			return nil, err
-		}
+		errs = append(errs, c.delegCred.Release())
 		c.delegCred = nil
 	}
 
 	if c.id == nil {
-		return nil, nil
+		return nil, errors.Join(errs...)
 	}
 	var cMinor C.OM_uint32
 	var cOutToken C.gss_buffer_desc = C.gss_empty_buffer // allocated by GSSAPI;  released by *1
@@ -385,10 +394,12 @@ func (c *SecContext) Delete() ([]byte, error) {
 	c.id = nil
 	outToken := C.GoBytes(cOutToken.value, C.int(cOutToken.length))
 
-	return outToken, makeStatus(cMajor, cMinor)
+	errs = append(errs, makeStatus(cMajor, cMinor))
+
+	return outToken, errors.Join(errs...)
 }
 
-// ProcessToken is used to process error tokens from the peero.  No idea how to test this!
+// ProcessToken is used to process error tokens from the peer.  No idea how to test this!
 func (c *SecContext) ProcessToken(token []byte) error {
 	var cMinor C.OM_uint32
 	cInputToken, pinner := bytesToCBuffer(token, nil)

--- a/seccontext_mac.go
+++ b/seccontext_mac.go
@@ -56,13 +56,14 @@ func mkChannelBindings(cb *g.ChannelBinding, pinner *runtime.Pinner) (C.gss_chan
 		pinner.Pin(addrBuf.value)
 	}
 
-	buf := C.gss_buffer_desc{
-		length: C.size_t(len(cb.Data)),
-		value:  unsafe.Pointer(&cb.Data[0]),
+	if len(cb.Data) > 0 {
+		buf := C.gss_buffer_desc{
+			length: C.size_t(len(cb.Data)),
+			value:  unsafe.Pointer(&cb.Data[0]),
+		}
+		C._set_cb_data(&cCB, buf)
+		pinner.Pin(&cb.Data[0])
 	}
-
-	C._set_cb_data(&cCB, buf)
-	pinner.Pin(&cb.Data[0])
 
 	return &cCB, pinner
 }

--- a/seccontext_unix.go
+++ b/seccontext_unix.go
@@ -40,8 +40,11 @@ func mkChannelBindings(cb *g.ChannelBinding, pinner *runtime.Pinner) (C.gss_chan
 	}
 
 	cCB.application_data.length = C.size_t(len(cb.Data))
-	cCB.application_data.value = unsafe.Pointer(&cb.Data[0])
-	pinner.Pin(&cb.Data[0])
+
+	if len(cb.Data) > 0 {
+		cCB.application_data.value = unsafe.Pointer(&cb.Data[0])
+		pinner.Pin(&cb.Data[0])
+	}
 
 	return &cCB, pinner
 }

--- a/status.go
+++ b/status.go
@@ -15,14 +15,14 @@ import (
 import "C"
 
 // FatalCallingError extends the go-gssapi FatalStatus type with a C-binding specific
-// calling error (RFC 2744 § 3.9.1).  It is retrurned in cases that the C library
+// calling error (RFC 2744 § 3.9.1).  It is returned in cases that the C library
 // populates bits 24-31 of the major error code returned from its functions.  These
-// are programming errors made by the caller of the GSSPAI routines.  Note that not
+// are programming errors made by the caller of the GSSAPI routines.  Note that not
 // all of the C implementations make use of these calling errors - MIT does; Heimdal does
 // not and will happily segfault instead.
 //
 // The Error() method adds details about the calling error to its output.  Generally this
-// is sufficinent; if the caller needs to inspect the calling error it can check using
+// is sufficient; if the caller needs to inspect the calling error it can check using
 // [errors.Is()] and the ErrInaccessibleRead, ErrInaccessibleWrite and ErrBadStructure
 // values.
 type FatalCallingError struct {
@@ -185,11 +185,12 @@ func gssMinorErrors(mechStatus C.OM_uint32, mech g.GssMech) []error {
 			break
 		}
 
-		// *1 Release buffer
-		defer C.gss_release_buffer(&minor, &statusString)
-
 		s := C.GoStringN((*C.char)(statusString.value), C.int(statusString.length))
 		ret = append(ret, errors.New(s))
+
+		// *1 Release buffer
+		C.gss_release_buffer(&minor, &statusString)
+		statusString = C.gss_empty_buffer
 
 		// all done when the message context is set to zero by gss_display_status
 		if msgCtx == 0 {

--- a/symbols.go
+++ b/symbols.go
@@ -32,16 +32,9 @@ func readSymbols() {
 		"gss_add_cred_from",     // Credential Store extension
 	}
 
-	cDlHandle := C.dlopen(nil, C.RTLD_NOW)
-	if cDlHandle == nil {
-		panic("failed to open library")
-	}
-
-	defer C.dlclose(cDlHandle)
-
 	for _, sym := range syms {
 		symStr := C.CString(sym)
-		ptr := C.dlsym(cDlHandle, symStr)
+		ptr := C.dlsym(C.RTLD_DEFAULT, symStr)
 		optionalSymbols[sym] = ptr
 		C.free(unsafe.Pointer(symStr))
 	}


### PR DESCRIPTION
Fixes:

  1. gssMinorErrors: defer inside a loop leaks intermediate buffers — status.go:189

  for {
      major := C.gss_display_status(&minor, mechStatus, 2, cMechOid, &msgCtx, &statusString)
      ...
      // *1 Release buffer
      defer C.gss_release_buffer(&minor, &statusString)
      ...
  }

  defer runs at function return, not loop iteration. Each pass through the loop reassigns statusString.value to a freshly GSSAPI-allocated buffer; the previous
  allocation is overwritten and leaks. At function exit, every deferred call references the same &statusString and tries to release the (now last) buffer —
  first one releases it, the rest pass a buffer whose value was nulled out by gss_release_buffer, so they're no-ops (only by virtue of how gss_release_buffer
  behaves). Fix: release at the bottom of each iteration, e.g.

  C.gss_release_buffer(&minor, &statusString)
  statusString = C.gss_empty_buffer

  2. Credential.Add: pin leak — cred.go:204-208

  var cMechOid C.gss_OID = C.GSS_C_NO_OID
  pinner := &runtime.Pinner{}
  if mech != nil {
      cMechOid, _ = oid2Coid(mech.Oid(), pinner)
  }

  There is no defer pinner.Unpin(). The OID bytes stay pinned for the life of the program after every call. cred_ext.go:332-333 (AddFrom) gets this right.

  3. Credential.Add / Credential.AddFrom lose usage on the returned credential — cred.go:235, cred_ext.go:373

  return &Credential{id: cCredOut}, nil

  usage and isFromNoName are zero-valued. The FreeBSD/Heimdal workarounds in Inquire / InquireByMech rely on c.usage to return the right field; those will now
  report CredUsageInitiateOnly (zero value) regardless of what the caller asked for. AcquireCredential (cred.go:58) populates these fields — Add{,From} should
  too.

  4. mkChannelBindings panics on empty cb.Data — seccontext_unix.go:43-44, seccontext_mac.go:61,65

  cCB.application_data.length = C.size_t(len(cb.Data))
  cCB.application_data.value = unsafe.Pointer(&cb.Data[0])
  pinner.Pin(&cb.Data[0])

  &cb.Data[0] panics with "index out of range" when cb.Data is empty, even though application_data of length 0 is perfectly legal in GSSAPI and the addr fields
  above handle it correctly. Guard with if len(cb.Data) > 0.

  5. SecContext.Delete leaks on partial failure — seccontext.go:354-373

  if c.initiatorName != nil {
      if err := c.initiatorName.Release(); err != nil {
          return nil, err   // acceptorName, delegCred, c.id all leak
      }
      c.initiatorName = nil
  }

  If any sub-release fails, the rest of the cleanup is skipped, including gss_delete_sec_context. Better to accumulate errors (e.g. errors.Join) and run all
  cleanup paths unconditionally.

  6. acceptSecContext / Continue leak output on early error — seccontext.go:200-201, :302

  When gss_accept_sec_context returns an error that isn't GSS_S_CONTINUE_NEEDED, the code returns immediately without releasing cOutToken, cInitiatorName, or
  cGssDelegCred. Per RFC 2744 §5.1, an output token may be returned alongside a failure (error tokens for the peer); current code drops it on the floor and
  leaks the GSSAPI-allocated buffer. Same in Continue. Move the defer C.gss_release_buffer(&cMinor, &cOutToken) above the major-status check, and release the
  name/cred if they were populated.

  7. names.go:129 returns a misleading status on a non-GSSAPI error

  nameType, err := g.NameTypeFromOid(oid)
  if err != nil {
      return "", g.GSS_NO_OID, makeStatus(major, minor)
  }

  At this point major == GSS_S_COMPLETE and minor == 0, so makeStatus returns nil. The caller gets (empty, GSS_NO_OID, nil) — a successful return with no useful
   data. Should be return "", g.GSS_NO_OID, err.

  cgo / memory-model concerns

  8. dlclose immediately after dlsym — symbols.go:35-47

  cDlHandle := C.dlopen(nil, C.RTLD_NOW)
  ...
  defer C.dlclose(cDlHandle)

  for _, sym := range syms {
      ...
      ptr := C.dlsym(cDlHandle, symStr)
      optionalSymbols[sym] = ptr
      ...
  }

  The cached pointers are kept and used long after dlclose. POSIX says a handle returned by dlopen(NULL,...) may or may not need a matching dlclose; the
  resolved addresses are only guaranteed valid while the handle is open. In practice this works because the main image is never actually unloaded, but it's
  spec-fragile. Either drop the dlclose, or use RTLD_DEFAULT as a pseudo-handle ((void *)0 on glibc, ((void *)-2) on macOS) without an open/close pair.

  9. kvset.kvset is a const-typed pointer that we mutate — cred_ext.go:153-187

  typedef const struct gss_key_value_set_struct gss_key_value_set_desc;
  typedef const gss_key_value_set_desc *gss_const_key_value_set_t;

  kvs.kvset.elements = unsafe.SliceData(elms)   // mutating through a pointer-to-const
  kvs.kvset.count    = C.OM_uint32(len(elms))

  C semantics: writes through a const T * are UB. cgo doesn't enforce it, but it works only by accident of the current toolchain. Hold the value as a non-const
  *C.gss_key_value_set_desc internally and only cast to the const type at the call site.

  10. Positional struct init for Credential is brittle — seccontext.go:234, 339

  c.delegCred = &Credential{cGssDelegCred, g.CredUsageInitiateOnly, false}

  If field order changes (which already happened — isFromNoName was added), every positional init silently re-binds. Switch to named fields.

  11. oid2Coid (mac) — note the OM_uint32 width

  helpers_mac.go:50 casts len(oid) (Go int) to C.OM_uint32. Realistically OIDs are tiny so this is fine, but worth a comment or a length guard analogous to the
  ErrTooLarge checks elsewhere.

  12. cOutToken != C.gss_empty_buffer comparisons are wrong — multiple sites

  var cOutToken C.gss_buffer_desc = C.gss_empty_buffer
  ...
  if cOutToken != C.gss_empty_buffer {
      outToken = C.GoBytes(cOutToken.value, C.int(cOutToken.length)) }

  gss_empty_buffer is a global gss_buffer_desc with {length: 0, value: NULL}. The != compares the whole struct value, so this only matches when length is 0 AND
  value is NULL — most GSSAPI impls return {0, NULL} when no token is produced, so it works, but the intent ("did GSSAPI give us a buffer?") is muddier than
  cOutToken.length > 0. Prefer the explicit length test, which is what C.GoBytes would interpret anyway. Affects seccontext.go:134, 207, 314.

  Minor / polish

  - oidset.go is missing the SPDX header that every other file has (line 1 jumps straight to package gssapi).
  - Comment typos: provider.go:44 "operate on a m." (truncated); cred.go:79, 150 "releaseed"; seccontext.go:391 "peero"; status.go:20, 25, 26 "retrurned" / "GSSPAI" / "sufficinent"; cred_ext.go:67-68 indentation mismatch.
  - oid2String in helpers.go:23 over-allocates asn1.ObjectIdentifier with capacity 100 — unnecessary; asn1.Unmarshal accepts a nil/empty slice and grows as needed.
  - cred_ext.go:330 has the // coverage-ignore directive, but AddFrom is reachable from the public extension interface — worth a test or at least a note about why it's untested.
  - kvset.kv() (line 216) and kvset.Get() (line 208) are only used in tests by the look of it; if so, move them to a _test.go file or add a comment.