### PR TITLE
Claude ultra fixes

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
             go-version: '1.22.x'
-      - name: Install Ubuntu upackages
+      - name: Install Ubuntu packages
         run: |
               sudo apt-get install -y krb5-user libkrb5-dev pkg-config
       - name: Generate test includes

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -178,7 +178,7 @@ jobs:
           uname -a
           if [ -e /etc/os-release ]; then cat /etc/os-release; fi
 
-    - name: Install Ubuntu upackages
+    - name: Install Ubuntu packages
       if: ${{ runner.os == 'Linux'}}
       run: |
           if [ "${{ matrix.krb5-version }}" = "mit" ]; then

--- a/.github/workflows/light-tests.yaml
+++ b/.github/workflows/light-tests.yaml
@@ -77,7 +77,7 @@ jobs:
           uname -a
           if [ -e /etc/os-release ]; then cat /etc/os-release; fi
 
-    - name: Install Ubuntu upackages
+    - name: Install Ubuntu packages
       if: ${{ runner.os == 'Linux'}}
       run: |
           if [ "${{ matrix.krb5-version }}" = "mit" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Expect respectful collaboration, a focus on substance over perfection, and a wil
 Let’s build something great, together.
 
 
-## Community guideliens
+## Community guidelines
 
 We believe that open source thrives on respectful collaboration and a diversity of perspectives.  This
 leads to better solutions, more creativity, and a more engaging project.
@@ -33,7 +33,7 @@ This project is a Go wrapper around a C-based GSSAPI library. Contributions shou
 
 ### API Boundary
 The public API of this provider should only expose the interface described by the 
-[generic Go GSSAPI specification](https://github.com/golang-auth/go-gssapi/v3).
+[generic Go GSSAPI specification](https://pkg.go.dev/github.com/golang-auth/go-gssapi/v3).
 
 Exposing provider-specific functionality (e.g., for configuring the underlying C library) is discouraged as it
 dilutes the value of the provider independent interfaces. Such changes require careful review and should only be implemented when absolutely necessary.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Go-GSSAPI C bindings provider
 
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/golang-auth/go-gssapi-c)
-[![Git Workflow](https://img.shields.io/github/actions/workflow/status/golang-auth/go-gssapi-c/full-tests.yml?branch=main/
-)](https://img.shields.io/github/actions/workflow/status/golang-auth/go-gssapi-c/full-tests.yml?branch=main)
+[![Git Workflow](https://img.shields.io/github/actions/workflow/status/golang-auth/go-gssapi-c/full-tests.yml?branch=main)](https://github.com/golang-auth/go-gssapi-c/actions/workflows/full-tests.yml)
 
 The go-gssapi-c package is a provider that implements the
 [Go GSSAPI][gssapi-v3] interfaces for access to a C library implementing
@@ -20,7 +19,7 @@ combinations:
     * FreeBSD Kerberos:
       * Heimdal for FreeBSD before version 15
       * MIT from version 15
-    * MIT Kerberos (from ports for FreeBSD before versions 15)
+    * MIT Kerberos (from ports for FreeBSD before version 15)
     * Heimdal Kerberos 7.8.0 (from ports)
  * OpenBSD with Heimdal Kerberos 7.8.0 from ports
 
@@ -68,12 +67,12 @@ and the `usepkgconfig` build tag is supplied.
 FreeBSD versions prior to v15 ship with a version of Heimdal that was forked
 a long time ago.  FreeBSD 15 ships with a modern MIT version instead.
 As with MacOS, this base implementation will be used by default.  On FreeBSD 15
-it is necessary to supply the `usepkgconf` build tag to include the correct
+it is necessary to supply the `usepkgconfig` build tag to include the correct
 libraries - we will remove this requirement once FreeBSD 14 is deprecated.
 
 The ports tree can be used to install a more modern Heimdal version (or MIT
 Kerberos before FBSD 15) and those versions can be used by this provider by
-supplying the `usepkgconf` build tag.  Note that it is not possible to
+supplying the `usepkgconfig` build tag.  Note that it is not possible to
 support both MIT Kerberos and Heimdal from ports simultaneously.
 
 ### OpenBSD

--- a/cred_ext.go
+++ b/cred_ext.go
@@ -327,7 +327,6 @@ func (c *Credential) StoreInto(mech g.GssMech, usage g.CredUsage, overwrite bool
 		case err != nil:
 			return nil, 0, err
 		}
-		// If MechFromOid fails, skip that OID (could log or handle differently if desired)
 	}
 
 	return mechs, g.CredUsage(cUsageStored), nil
@@ -335,6 +334,12 @@ func (c *Credential) StoreInto(mech g.GssMech, usage g.CredUsage, overwrite bool
 
 // nolint:staticcheck //  Not sure how to test this!
 func (c *Credential) AddFrom(name g.GssName, mech g.GssMech, usage g.CredUsage, initiatorLifetime *g.GssLifetime, acceptorLifetime *g.GssLifetime, mutate bool, opts ...g.CredStoreOption) (g.Credential, error) { // coverage-ignore
+	// gss_add_cred_from is built on top of gss_add_cred, which is non-functional
+	// on Heimdal versions before the rewrite (signalled by gss_duplicate_cred).
+	if isHeimdal() && !isHeimdalWorkingAddCred() {
+		return nil, makeCustomStatus(C.GSS_S_UNAVAILABLE, fmt.Errorf("gss_add_cred_from is not available when using this version of Heimdal"))
+	}
+
 	var cMechOid C.gss_OID = C.GSS_C_NO_OID
 	pinner := &runtime.Pinner{}
 	defer pinner.Unpin()

--- a/cred_ext_test.go
+++ b/cred_ext_test.go
@@ -365,5 +365,5 @@ func TestAddCredentialFrom(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// TOODO: its not clear how to test this
+	// TODO: it's not clear how to test this
 }

--- a/helpers.go
+++ b/helpers.go
@@ -158,14 +158,6 @@ func gssReleaseName(minor *C.OM_uint32, name *C.gss_name_t) C.OM_uint32 {
 	return C.gss_release_name(minor, name)
 }
 
-func gssReleaseBuffer(minor *C.OM_uint32, buf *C.gss_buffer_desc) C.OM_uint32 {
-	return C.gss_release_buffer(minor, buf)
-}
-
-func gssReleaseOidSet(minor *C.OM_uint32, set *C.gss_OID_set) C.OM_uint32 {
-	return C.gss_release_oid_set(minor, set)
-}
-
 func extractBufferSet(bs C.gss_buffer_set_t) [][]byte {
 	out := make([][]byte, bs.count)
 

--- a/mechs.go
+++ b/mechs.go
@@ -27,7 +27,6 @@ func (p *provider) IndicateMechs() ([]g.GssMech, error) {
 	ret := make([]g.GssMech, 0, cMechSet.count)
 	mechOids := oidsFromGssOidSet(cMechSet)
 
-	// Use unsafe to access the OID set elements
 	for _, oid := range mechOids {
 		mech, err := g.MechFromOid(oid)
 		switch {
@@ -39,7 +38,6 @@ func (p *provider) IndicateMechs() ([]g.GssMech, error) {
 		case err != nil:
 			return nil, err
 		}
-		// If MechFromOid fails, skip that OID (could log or handle differently if desired)
 	}
 	return ret, nil
 }

--- a/oidset.go
+++ b/oidset.go
@@ -54,12 +54,14 @@ func (o *oidSet) Release() error {
 	if o == nil || o.oidSet == nil {
 		return nil
 	}
+	defer o.pinner.Unpin()
 
 	var minor C.OM_uint32
 	cMajor := C.gss_release_oid_set(&minor, &o.oidSet)
 	if cMajor != C.GSS_S_COMPLETE {
 		return makeStatus(cMajor, minor)
 	}
-	o.pinner.Unpin()
+
 	return nil
+
 }

--- a/oidset_test.go
+++ b/oidset_test.go
@@ -37,5 +37,7 @@ func TestOidSet(t *testing.T) {
 			assert.NoErrorFatal(err)
 			assert.Equal(mechs[i].OidString(), oidString)
 		}
+
+		assert.NoError(oidSet.Release())
 	}
 }

--- a/seccontext.go
+++ b/seccontext.go
@@ -63,14 +63,14 @@ func (provider) InitSecContext(name g.GssName, opts ...g.InitSecContextOption) (
 		return nil, fmt.Errorf("bad name type %T, %w", name, g.ErrBadName)
 	}
 
-	// stash the initiator name so we can use it during the context establishment process
+	// stash the target (acceptor) name so we can use it during the context establishment process
 	savedName, err := nameImpl.Duplicate()
 	if err != nil {
 		return nil, fmt.Errorf("%w duplicating name: %w", g.ErrFailure, err)
 	}
 
 	ctx := newSecContext(true)
-	ctx.initiatorName = savedName.(*GssName)
+	ctx.acceptorName = savedName.(*GssName)
 	ctx.mech = o.Mech
 	ctx.initOptions = &o
 
@@ -111,7 +111,7 @@ func (c *SecContext) initSecContext() ([]byte, g.SecContextInfoPartial, error) {
 		cGssCred = credImpl.id
 	}
 
-	var cGssTargetName C.gss_name_t = c.initiatorName.name
+	var cGssTargetName C.gss_name_t = c.acceptorName.name
 
 	var cChBindings C.gss_channel_bindings_t = C.GSS_C_NO_CHANNEL_BINDINGS
 	if c.initOptions.ChannelBinding != nil {
@@ -124,24 +124,29 @@ func (c *SecContext) initSecContext() ([]byte, g.SecContextInfoPartial, error) {
 	var cActualMech C.gss_OID = C.GSS_C_NO_OID           // DO NOT FREE
 	cMajor := C.gss_init_sec_context(&cMinor, cGssCred, &cGssCtxID, cGssTargetName, cMechOid, C.OM_uint32(c.initOptions.Flags), C.OM_uint32(c.initOptions.Lifetime.Seconds()), cChBindings, nil, &cActualMech, &cOutToken, &cRetFlags, &cTimeRec)
 
-	if cMajor != C.GSS_S_COMPLETE && (cMajor&C.GSS_S_CONTINUE_NEEDED) == 0 {
-		return nil, g.SecContextInfoPartial{}, makeMechStatus(cMajor, cMinor, c.initOptions.Mech)
-	}
-
 	// *1  release GSSAPI allocated buffer
 	defer C.gss_release_buffer(&cMinor, &cOutToken)
 
+	// GSSAPI may emit an error token on fatal returns (RFC 2744 §5.20)
+	// that the caller is expected to forward to the peer.
 	var outToken []byte = nil
 	if cOutToken.length > 0 {
 		outToken = C.GoBytes(cOutToken.value, C.int(cOutToken.length))
 	}
+
+	if cMajor != C.GSS_S_COMPLETE && (cMajor&C.GSS_S_CONTINUE_NEEDED) == 0 {
+		return outToken, g.SecContextInfoPartial{}, makeMechStatus(cMajor, cMinor, c.initOptions.Mech)
+	}
+
 	c.continueNeeded = (cMajor & C.GSS_S_CONTINUE_NEEDED) > 0
 	c.id = cGssCtxID
 
 	ctxFlags, protFlag, transFlag := splitFlags(cRetFlags)
 
+	// gss_init_sec_context does not return an initiator name (the initiator
+	// knows itself via its credential); callers should call Inquire() once the
+	// context is fully established to get the authenticated name pair.
 	info := g.SecContextInfoPartial{
-		InitiatorName:       c.initiatorName,
 		Flags:               ctxFlags,
 		ExpiresAt:           timeRecToGssLifetime(cTimeRec),
 		LocallyInitiated:    c.isInitiator,
@@ -218,30 +223,35 @@ func (c *SecContext) acceptSecContext(inputToken []byte) ([]byte, g.SecContextIn
 
 	c.continueNeeded = (cMajor & C.GSS_S_CONTINUE_NEEDED) > 0
 	c.id = cGssCtxID
-	c.initiatorName = nameFromGssInternal(cInitiatorName)
+	// Some mechs (e.g. SPNEGO mid-handshake) defer setting src_name until the
+	// context is fully established; leave c.initiatorName nil so the next
+	// Continue() round will re-request it.
+	if cInitiatorName != C.GSS_C_NO_NAME {
+		c.initiatorName = nameFromGssInternal(cInitiatorName)
+	}
 
 	ctxFlags, protFlag, transFlag := splitFlags(cRetFlags)
 
+	if cGssDelegCred != C.GSS_C_NO_CREDENTIAL {
+		c.delegCred = &Credential{id: cGssDelegCred, usage: g.CredUsageInitiateOnly}
+	}
+
 	info := g.SecContextInfoPartial{
-		InitiatorName:    c.initiatorName,
-		Flags:            ctxFlags,
-		ExpiresAt:        timeRecToGssLifetime(cTimeRec),
-		LocallyInitiated: c.isInitiator,
-		FullyEstablished: !c.continueNeeded,
-		ProtectionReady:  protFlag,
-		Transferrable:    transFlag,
+		InitiatorName:       c.initiatorName,
+		Flags:               ctxFlags,
+		ExpiresAt:           timeRecToGssLifetime(cTimeRec),
+		LocallyInitiated:    c.isInitiator,
+		FullyEstablished:    !c.continueNeeded,
+		ProtectionReady:     protFlag,
+		Transferrable:       transFlag,
+		DelegatedCredential: c.delegCred,
 	}
 	if cActualMech != C.GSS_C_NO_OID {
 		mech, err := g.MechFromOid(oidFromGssOid(cActualMech))
 		if err != nil {
-			return nil, g.SecContextInfoPartial{}, fmt.Errorf("unknown mech returned from gss_accept_sec_context: %w", g.ErrBadMech)
+			return outToken, info, fmt.Errorf("unknown mech returned from gss_accept_sec_context: %w", g.ErrBadMech)
 		}
 		info.Mech = mech
-	}
-
-	if cGssDelegCred != C.GSS_C_NO_CREDENTIAL {
-		c.delegCred = &Credential{id: cGssDelegCred, usage: g.CredUsageInitiateOnly, isFromNoName: false}
-		info.DelegatedCredential = c.delegCred
 	}
 
 	return outToken, info, nil
@@ -292,7 +302,7 @@ func (c *SecContext) Continue(inputToken []byte) ([]byte, g.SecContextInfoPartia
 	cMechOid, _ := oid2Coid(mech, pinner)
 
 	if c.isInitiator {
-		cMajor = C.gss_init_sec_context(&cMinor, C.GSS_C_NO_CREDENTIAL, &c.id, c.initiatorName.name, cMechOid, 0, 0, nil, &cInputToken, &cActualMech, &cOutToken, &cRetFlags, &cTimeRec)
+		cMajor = C.gss_init_sec_context(&cMinor, C.GSS_C_NO_CREDENTIAL, &c.id, c.acceptorName.name, cMechOid, 0, 0, nil, &cInputToken, &cActualMech, &cOutToken, &cRetFlags, &cTimeRec)
 	} else {
 		// Ask for the initiator name and delegated credential if we don't already have them
 		var cpInitiatorName *C.gss_name_t = nil
@@ -315,7 +325,7 @@ func (c *SecContext) Continue(inputToken []byte) ([]byte, g.SecContextInfoPartia
 		outToken = C.GoBytes(cOutToken.value, C.int(cOutToken.length))
 	}
 
-	if cMajor != C.GSS_S_COMPLETE && cMajor != C.GSS_S_CONTINUE_NEEDED {
+	if cMajor != C.GSS_S_COMPLETE && (cMajor&C.GSS_S_CONTINUE_NEEDED) == 0 {
 		var errs []error
 		errs = append(errs, gssRelease(gssReleaseCred, &cGssDelegCred))  // *3   release delegated credential
 		errs = append(errs, gssRelease(gssReleaseName, &cInitiatorName)) // *2   release initiator name
@@ -332,26 +342,30 @@ func (c *SecContext) Continue(inputToken []byte) ([]byte, g.SecContextInfoPartia
 
 	ctxFlags, protFlag, transFlag := splitFlags(cRetFlags)
 
+	if cGssDelegCred != C.GSS_C_NO_CREDENTIAL {
+		c.delegCred = &Credential{id: cGssDelegCred, usage: g.CredUsageInitiateOnly}
+	}
+
 	info := g.SecContextInfoPartial{
-		InitiatorName:    c.initiatorName,
-		Flags:            ctxFlags,
-		ExpiresAt:        timeRecToGssLifetime(cTimeRec),
-		LocallyInitiated: c.isInitiator,
-		FullyEstablished: !c.continueNeeded,
-		ProtectionReady:  protFlag,
-		Transferrable:    transFlag,
+		InitiatorName:       c.initiatorName,
+		Flags:               ctxFlags,
+		ExpiresAt:           timeRecToGssLifetime(cTimeRec),
+		LocallyInitiated:    c.isInitiator,
+		FullyEstablished:    !c.continueNeeded,
+		ProtectionReady:     protFlag,
+		Transferrable:       transFlag,
+		DelegatedCredential: c.delegCred,
 	}
 	if cActualMech != C.GSS_C_NO_OID {
 		mech, err := g.MechFromOid(oidFromGssOid(cActualMech))
 		if err != nil {
-			return nil, g.SecContextInfoPartial{}, fmt.Errorf("unknown mech returned from gss_accept_sec_context: %w", g.ErrBadMech)
+			fnName := "gss_accept_sec_context"
+			if c.isInitiator {
+				fnName = "gss_init_sec_context"
+			}
+			return outToken, info, fmt.Errorf("unknown mech returned from %s: %w", fnName, g.ErrBadMech)
 		}
 		info.Mech = mech
-	}
-
-	if cGssDelegCred != C.GSS_C_NO_CREDENTIAL {
-		c.delegCred = &Credential{id: cGssDelegCred, usage: g.CredUsageInitiateOnly, isFromNoName: false}
-		info.DelegatedCredential = c.delegCred
 	}
 
 	return outToken, info, nil


### PR DESCRIPTION
Fixes:

  - acceptSecContext:221 sets c.initiatorName unconditionally — nameFromGssInternal returns a non-nil wrapper around a possibly-NULL handle, so the guard in Continue() line 298 never fires on multi-round mechanisms.
  - On the initiator side, SecContextInfoPartial.InitiatorName is being populated with the target name (which the code stashes in c.initiatorName per InitSecContext:72-73).
  - initSecContext now registers the gss_release_buffer defer and extracts outToken before the fatal-error return, so error tokens are no longer leaked and are forwarded to the caller — acceptSecContext and Continue now move delegated-credential storage (c.delegCred = …) above the MechFromOid check, so on an unknown-mech failure the credential isn't leaked. The mech-unknown error path now also returns the populated outToken and info instead of empty values.
  - info.DelegatedCredential is now assigned from c.delegCred outside the per-round guard, so it persists across Continue() rounds instead of flickering on/off.
  - AddFrom now mirrors Add's broken-Heimdal guard.
  - Deleted dead gssReleaseBuffer.
  - Continue:318 uses != CONTINUE_NEEDED instead of the bitmask form used in the sibling functions.
  - oidSet.Release leaks the pinner if gss_release_oid_set returns non-COMPLETE.
  - Comment/error message typo fixes